### PR TITLE
ci: restrict test workflow token permissions (#105)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ 1.x ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Problem: Code scanning reports that the test workflow does not declare explicit GITHUB_TOKEN permissions. Fixes #105.

Root cause: The workflow inherited repository or organization default token scopes.

Solution: Added workflow-level permissions with contents: read, which is enough for checkout and the existing test matrix.

Validation:
- PATH="/Users/kid/Library/Application Support/Herd/bin:$PATH" COMPOSER_ALLOW_XDEBUG=1 XDEBUG_MODE=coverage composer test

Risk/rollback: Low. CI-only permission tightening; rollback by reverting the workflow commit if a future job needs an extra token scope.
