### PR TITLE
feat: add WebP and PDF output formats (#87)

### DIFF
--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -30,6 +30,8 @@ Controls the default output format for QR codes.
 - `png` - PNG image format (requires ext-imagick)
 - `svg` - SVG vector format
 - `eps` - Encapsulated PostScript format
+- `webp` - WebP image format (requires Imagick WebP support)
+- `pdf` - PDF document format (requires Imagick PDF support)
 
 ### Size
 
@@ -197,6 +199,8 @@ $qrCode = QrCode::size(300)
 - PNG: For web display, email, and raster graphics
 - SVG: For scaling, print, and vector graphics
 - EPS: For professional printing and design software
+- WebP: For modern web delivery when browser support is acceptable
+- PDF: For document workflows that need a standalone QR code page
 
 ## Cache Configuration
 

--- a/docs/10-api-reference.md
+++ b/docs/10-api-reference.md
@@ -259,7 +259,7 @@ public function format(string $format): self
 ```
 
 **Parameters:**
-- `$format` (string): Output format - 'png', 'svg', 'eps'
+- `$format` (string): Output format - 'png', 'svg', 'eps', 'webp', 'pdf'
 
 **Returns:** Self for method chaining
 

--- a/src/Concerns/ConfiguresQrCode.php
+++ b/src/Concerns/ConfiguresQrCode.php
@@ -43,7 +43,7 @@ trait ConfiguresQrCode
 
     public function format(string $format): self
     {
-        throw_unless(in_array($format, ['svg', 'eps', 'png']), InvalidArgumentException::class, "\$format must be svg, eps, or png. {$format} is not a valid.");
+        throw_unless(in_array($format, ['svg', 'eps', 'png', 'webp', 'pdf'], true), InvalidArgumentException::class, "\$format must be svg, eps, png, webp, or pdf. {$format} is not a valid.");
 
         $this->format = $format;
 
@@ -160,8 +160,8 @@ trait ConfiguresQrCode
 
     public function getFormatter(): ImageBackEndInterface
     {
-        if ($this->format === 'png') {
-            return new ImagickImageBackEnd('png');
+        if (in_array($this->format, ['png', 'webp', 'pdf'], true)) {
+            return new ImagickImageBackEnd($this->format);
         }
 
         if ($this->format === 'eps') {

--- a/tests/QrCodeOutputFormatTest.php
+++ b/tests/QrCodeOutputFormatTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Akira\QrCode\QrCode;
+use BaconQrCode\Renderer\Image\ImagickImageBackEnd;
+
+it('uses imagick backend for webp output', function (): void {
+    $qrCode = resolve(QrCode::class)->format('webp');
+
+    expect($qrCode->getFormatter())->toBeInstanceOf(ImagickImageBackEnd::class);
+});
+
+it('generates raw webp output', function (): void {
+    $qrCode = resolve(QrCode::class)->format('webp');
+    $output = $qrCode->generateRaw('WebP payload');
+
+    expect($output)->toBeString();
+    expect(mb_substr((string) $output, 0, 4))->toBe('RIFF');
+    expect(mb_substr((string) $output, 8, 4))->toBe('WEBP');
+});
+
+it('uses imagick backend for pdf output', function (): void {
+    $qrCode = resolve(QrCode::class)->format('pdf');
+
+    expect($qrCode->getFormatter())->toBeInstanceOf(ImagickImageBackEnd::class);
+});
+
+it('generates raw pdf output', function (): void {
+    $qrCode = resolve(QrCode::class)->format('pdf');
+    $output = $qrCode->generateRaw('PDF payload');
+
+    expect($output)->toBeString();
+    expect(mb_substr((string) $output, 0, 4))->toBe('%PDF');
+});


### PR DESCRIPTION
Problem: The package only accepted png, svg, and eps output formats. Fixes #87.

Root cause: format() validation and formatter selection did not expose additional Imagick-backed formats.

Solution: Added WebP and PDF as supported formats through ImagickImageBackEnd, updated format docs, and added Pest coverage for backend selection and raw output signatures.

Validation:
- PATH="/Users/kid/Library/Application Support/Herd/bin:$PATH" COMPOSER_ALLOW_XDEBUG=1 XDEBUG_MODE=coverage composer test

Risk/rollback: Medium. WebP and PDF depend on Imagick format support in the host environment; rollback by reverting the format commit if a deployment lacks those delegates.
