### PR TITLE
fix: correct eyeColor outer parameter names (#121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **qrcode:** Corrected `eyeColor()` named arguments from `outterRed`, `outterGreen`, and `outterBlue` to `outerRed`, `outerGreen`, and `outerBlue`; `inner*` now maps to the internal eye color and `outer*` maps to the external eye color.
+
 ## [1.2.0](https://github.com/akira-io/laravel-qrcode/compare/1.1.0...v1.2.0) (2026-05-31)
 
 ### Bug Fixes
@@ -119,4 +125,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps:** Bump bacon/bacon-qr-code from 3.0.1 to 3.0.3 ([9da57c6](https://github.com/akira-io/laravel-qrcode/commit/9da57c61c34e35d0ae2a6d6a31bbe8c1036e5b7a))
 - **deps-dev:** Bump nunomaduro/collision from 8.8.2 to 8.8.3 ([2afd434](https://github.com/akira-io/laravel-qrcode/commit/2afd43450d22b05d3e6cf3dc5a31fdd1e17d27c4))
 - **deps-dev:** Bump laravel/pint from 1.25.1 to 1.26.0 ([dc94ead](https://github.com/akira-io/laravel-qrcode/commit/dc94eadf710456b535bc6ca5fa8d9483042b392c))
-

--- a/docs/06-customization.md
+++ b/docs/06-customization.md
@@ -239,7 +239,7 @@ $qrCode = QrCode::eyeColor(0, 255, 0, 0)        // Eye 0: Red
 ```php
 // Eye with inner and outer colors
 $qrCode = QrCode::eyeColor(
-    eye: 0,
+    eyeNumber: 0,
     innerRed: 255,
     innerGreen: 0,
     innerBlue: 0,

--- a/docs/10-api-reference.md
+++ b/docs/10-api-reference.md
@@ -181,9 +181,9 @@ public function eyeColor(
     int $innerRed,
     int $innerGreen,
     int $innerBlue,
-    int $outterRed = 0,
-    int $outterGreen = 0,
-    int $outterBlue = 0
+    int $outerRed = 0,
+    int $outerGreen = 0,
+    int $outerBlue = 0
 ): self
 ```
 
@@ -192,11 +192,9 @@ public function eyeColor(
 - `$innerRed` (int): Inner square red (0-255)
 - `$innerGreen` (int): Inner square green (0-255)
 - `$innerBlue` (int): Inner square blue (0-255)
-- `$outterRed` (int, default 0): Outer square red (0-255)
-- `$outterGreen` (int, default 0): Outer square green (0-255)
-- `$outterBlue` (int, default 0): Outer square blue (0-255)
-
-> Note: the outer-color parameters are spelled `outter*` in the current implementation.
+- `$outerRed` (int, default 0): Outer square red (0-255)
+- `$outerGreen` (int, default 0): Outer square green (0-255)
+- `$outerBlue` (int, default 0): Outer square blue (0-255)
 
 **Returns:** Self for method chaining
 

--- a/docs/13-v2-output-contract.md
+++ b/docs/13-v2-output-contract.md
@@ -93,6 +93,38 @@ File output should not require migration:
 QrCode::format('png')->generate('Ticket payload', storage_path('ticket.png'));
 ```
 
+### Eye Color Named Arguments
+
+Before:
+
+```php
+QrCode::eyeColor(
+    eyeNumber: 0,
+    innerRed: 255,
+    innerGreen: 0,
+    innerBlue: 0,
+    outterRed: 0,
+    outterGreen: 0,
+    outterBlue: 255,
+);
+```
+
+After:
+
+```php
+QrCode::eyeColor(
+    eyeNumber: 0,
+    innerRed: 255,
+    innerGreen: 0,
+    innerBlue: 0,
+    outerRed: 0,
+    outerGreen: 0,
+    outerBlue: 255,
+);
+```
+
+Code that used positional arguments keeps the same `inner*`, then `outer*` argument order.
+
 ## Implementation Checklist
 
 - Add `toHtml()` before changing `generate()` behavior.

--- a/src/Concerns/ConfiguresQrCode.php
+++ b/src/Concerns/ConfiguresQrCode.php
@@ -66,16 +66,16 @@ trait ConfiguresQrCode
         return $this;
     }
 
-    public function eyeColor(int $eyeNumber, int $innerRed, int $innerGreen, int $innerBlue, int $outterRed = 0, int $outterGreen = 0, int $outterBlue = 0): self
+    public function eyeColor(int $eyeNumber, int $innerRed, int $innerGreen, int $innerBlue, int $outerRed = 0, int $outerGreen = 0, int $outerBlue = 0): self
     {
         throw_if($eyeNumber < 0 || $eyeNumber > 2, InvalidArgumentException::class, "\$eyeNumber must be 0, 1, or 2.  {$eyeNumber} is not valid.");
 
         $innerColor = new Color($innerRed, $innerGreen, $innerBlue);
-        $outterColor = new Color($outterRed, $outterGreen, $outterBlue);
+        $outerColor = new Color($outerRed, $outerGreen, $outerBlue);
 
         $this->eyeColors[$eyeNumber] = new EyeFill(
+            $this->colorAction->handle($outerColor),
             $this->colorAction->handle($innerColor),
-            $this->colorAction->handle($outterColor)
         );
 
         return $this;

--- a/src/Facades/QrCode.php
+++ b/src/Facades/QrCode.php
@@ -19,7 +19,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Akira\QrCode\QrCode mergeString(string $content, ?float $percentage = null)
  * @method static \Akira\QrCode\QrCode style(string $style, float $size = 0.5)
  * @method static \Akira\QrCode\QrCode eye(string $style)
- * @method static \Akira\QrCode\QrCode eyeColor(int $eyeNumber, int $innerRed, int $innerGreen, int $innerBlue, int $outterRed = 0, int $outterGreen = 0, int $outterBlue = 0)
+ * @method static \Akira\QrCode\QrCode eyeColor(int $eyeNumber, int $innerRed, int $innerGreen, int $innerBlue, int $outerRed = 0, int $outerGreen = 0, int $outerBlue = 0)
  * @method static \Akira\QrCode\QrCode gradient(int $startRed, int $startGreen, int $startBlue, int $endRed, int $endGreen, int $endBlue, string $type)
  * @method static \BaconQrCode\Renderer\Color\ColorInterface createColor(int $red, int $green, int $blue, ?int $alpha = null)
  * @method static \Akira\QrCode\QrCode cache(?int $ttl = null, ?string $prefix = null)

--- a/tests/QrCodeTest.php
+++ b/tests/QrCodeTest.php
@@ -70,9 +70,9 @@ test('color is passed to renderer', function (): void {
 });
 
 test('eye color is passed to renderer', function (): void {
-    $qrCode = (resolve(QrCode::class))->eyeColor(0, 0, 10, 50, 1, 8, 18);
-    $qrCode->eyeColor(1, 100, 20, 60, 2, 10, 20);
-    $qrCode->eyeColor(2, 200, 30, 70, 3, 12, 22);
+    $qrCode = (resolve(QrCode::class))->eyeColor(0, 1, 8, 18, 0, 10, 50);
+    $qrCode->eyeColor(1, 2, 10, 20, 100, 20, 60);
+    $qrCode->eyeColor(2, 3, 12, 22, 200, 30, 70);
 
     expect($qrCode->getFill()->getTopLeftEyeFill()->getExternalColor()->getRed())->toBe(0);
     expect($qrCode->getFill()->getTopRightEyeFill()->getExternalColor()->getRed())->toBe(100);
@@ -93,6 +93,25 @@ test('eye color is passed to renderer', function (): void {
     expect($qrCode->getFill()->getTopLeftEyeFill()->getInternalColor()->getBlue())->toBe(18);
     expect($qrCode->getFill()->getTopRightEyeFill()->getInternalColor()->getBlue())->toBe(20);
     expect($qrCode->getFill()->getBottomLeftEyeFill()->getInternalColor()->getBlue())->toBe(22);
+});
+
+it('accepts corrected outer color named arguments', function (): void {
+    $qrCode = (resolve(QrCode::class))->eyeColor(
+        eyeNumber: 0,
+        innerRed: 1,
+        innerGreen: 8,
+        innerBlue: 18,
+        outerRed: 0,
+        outerGreen: 10,
+        outerBlue: 50,
+    );
+
+    expect($qrCode->getFill()->getTopLeftEyeFill()->getExternalColor()->getRed())->toBe(0);
+    expect($qrCode->getFill()->getTopLeftEyeFill()->getExternalColor()->getGreen())->toBe(10);
+    expect($qrCode->getFill()->getTopLeftEyeFill()->getExternalColor()->getBlue())->toBe(50);
+    expect($qrCode->getFill()->getTopLeftEyeFill()->getInternalColor()->getRed())->toBe(1);
+    expect($qrCode->getFill()->getTopLeftEyeFill()->getInternalColor()->getGreen())->toBe(8);
+    expect($qrCode->getFill()->getTopLeftEyeFill()->getInternalColor()->getBlue())->toBe(18);
 });
 
 it('throws exception if eye color greater than 2', function (): void {


### PR DESCRIPTION
Problem:
- `eyeColor()` exposed misspelled named arguments: `outterRed`, `outterGreen`, and `outterBlue`.
- The public API docs repeated the misspelling, while named-argument examples already expected the corrected `outer*` names.

Root cause:
- The builder signature, facade PHPDoc, and local variable used the `outter*` spelling.
- The color handoff to BaconQrCode did not line up with the documented inner, then outer argument order.

Solution:
- Rename the public named arguments to `outerRed`, `outerGreen`, and `outerBlue`.
- Map `inner*` to the internal eye fill and `outer*` to the external eye fill.
- Update the facade method hint, API docs, customization named-argument example, v2 migration notes, and changelog.
- Add Pest coverage for corrected `outer*` named arguments.

Validation:
- `"/Users/kid/Library/Application Support/Herd/bin/php84" vendor/bin/pest tests/QrCodeTest.php --filter='eye color|corrected outer' --compact`
- `PATH="/Users/kid/Library/Application Support/Herd/bin:$PATH" COMPOSER_ALLOW_XDEBUG=1 XDEBUG_MODE=coverage composer test`

Risk/rollback:
- This is a breaking change for named-argument callers using `outter*`; those callers must rename to `outer*`.
- Positional callers keep the documented inner, then outer argument order. Callers that compensated for the previous reversed eye-fill mapping may need to swap the two color triplets.

Fixes #121
