### PR TITLE
fix(qrcode): default opaque foreground so svg qr codes render

### DIFF
--- a/config/qrcode.php
+++ b/config/qrcode.php
@@ -53,14 +53,15 @@ return [
     |--------------------------------------------------------------------------
     |
     | This option controls the default foreground color of the QR code.
-    | Format: [R, G, B, A] where each value is 0-255
+    | Format: [R, G, B, A] where R, G, B are 0-255 and A (opacity) is 0-100.
+    | Leave A unset for a fully opaque color.
     |
     */
     'color' => [
         (int) (env('QR_CODE_COLOR_R', 0)),
         (int) (env('QR_CODE_COLOR_G', 0)),
         (int) (env('QR_CODE_COLOR_B', 0)),
-        (int) (env('QR_CODE_COLOR_A', 0)),
+        is_numeric(env('QR_CODE_COLOR_A')) ? (int) env('QR_CODE_COLOR_A') : null,
     ],
 
     /*
@@ -69,14 +70,15 @@ return [
     |--------------------------------------------------------------------------
     |
     | This option controls the default background color of the QR code.
-    | Format: [R, G, B, A] where each value is 0-255 and A is optional between 0-127
+    | Format: [R, G, B, A] where R, G, B are 0-255 and A (opacity) is 0-100.
+    | Leave A unset for a fully opaque color.
     |
     */
     'background_color' => [
         (int) (env('QR_CODE_BACKGROUND_COLOR_R', 255)),
         (int) (env('QR_CODE_BACKGROUND_COLOR_G', 255)),
         (int) (env('QR_CODE_BACKGROUND_COLOR_B', 255)),
-        (int) (env('QR_CODE_BACKGROUND_COLOR_A', 0)),
+        is_numeric(env('QR_CODE_BACKGROUND_COLOR_A')) ? (int) env('QR_CODE_BACKGROUND_COLOR_A') : null,
     ],
 
     /*

--- a/tests/QrCodeOutputFormatTest.php
+++ b/tests/QrCodeOutputFormatTest.php
@@ -20,6 +20,14 @@ it('generates raw webp output', function (): void {
     expect(mb_substr((string) $output, 8, 4))->toBe('WEBP');
 });
 
+it('generates an opaque svg foreground by default', function (): void {
+    $svg = (string) resolve(QrCode::class)->format('svg')->generate('opacity check');
+
+    expect($svg)
+        ->toContain('fill="#000000"')
+        ->not->toContain('fill-opacity="0"');
+});
+
 it('uses imagick backend for pdf output', function (): void {
     $qrCode = resolve(QrCode::class)->format('pdf');
 


### PR DESCRIPTION
## Problem

Since bacon-qr-code v3 the alpha channel is honored on render. The config default foreground alpha was `0`, so generated SVGs carried `fill-opacity="0"` — every QR rendered fully transparent (invisible in browsers and PDF engines).

## Fix

Default foreground and background alpha to `null` (fully opaque) in `config/qrcode.php`. Alpha stays opt-in via `QR_CODE_COLOR_A` / `QR_CODE_BACKGROUND_COLOR_A` (range 0-100).

## Test

Added regression test asserting the default SVG contains `fill="#000000"` and not `fill-opacity="0"`.

Full suite: 121 passed.